### PR TITLE
Fix for SD+ dial press not working since Stream Deck v6.5

### DIFF
--- a/src/SharpDeck/Connectivity/IStreamDeckConnection.cs
+++ b/src/SharpDeck/Connectivity/IStreamDeckConnection.cs
@@ -38,9 +38,14 @@ namespace SharpDeck.Connectivity
         event EventHandler<DeviceEventArgs> DeviceDidDisconnect;
 
         /// <summary>
-        /// Occurs when a dial is pressed, or released.
+        /// Occurs when a dial is pressed.
         /// </summary>
-        event EventHandler<ActionEventArgs<DialPayload>> DialPress;
+        event EventHandler<ActionEventArgs<DialPayload>> DialDown;
+
+        /// <summary>
+        /// Occurs when a dial is released.
+        /// </summary>
+        event EventHandler<ActionEventArgs<DialPayload>> DialUp;
 
         /// <summary>
         /// Occurs when a dial rotates.

--- a/src/SharpDeck/Connectivity/Net/StreamDeckWebSocketConnection.cs
+++ b/src/SharpDeck/Connectivity/Net/StreamDeckWebSocketConnection.cs
@@ -55,9 +55,14 @@ namespace SharpDeck.Connectivity.Net
         public event EventHandler<DeviceEventArgs> DeviceDidDisconnect;
 
         /// <summary>
-        /// Occurs when a dial is pressed, or released.
+        /// Occurs when a dial is pressed.
         /// </summary>
-        public event EventHandler<ActionEventArgs<DialPayload>> DialPress;
+        public event EventHandler<ActionEventArgs<DialPayload>> DialDown;
+
+        /// <summary>
+        /// Occurs when a dial is released.
+        /// </summary>
+        public event EventHandler<ActionEventArgs<DialPayload>> DialUp;
 
         /// <summary>
         /// Occurs when a dial rotates.
@@ -441,8 +446,12 @@ namespace SharpDeck.Connectivity.Net
                     break;
 
                 // action specific
-                case "dialPress":
-                    this.DialPress?.Invoke(this, args.ToObject<ActionEventArgs<DialPayload>>());
+                case "dialDown":
+                    this.DialDown?.Invoke(this, args.ToObject<ActionEventArgs<DialPayload>>());
+                    break;
+
+                case "dialUp":
+                    this.DialUp?.Invoke(this, args.ToObject<ActionEventArgs<DialPayload>>());
                     break;
 
                 case "dialRotate":

--- a/src/SharpDeck/Connectivity/StreamDeckActionRegistry.cs
+++ b/src/SharpDeck/Connectivity/StreamDeckActionRegistry.cs
@@ -42,7 +42,8 @@ namespace SharpDeck.Connectivity
             connection.WillAppear += this.Action_WillAppear;
 
             // action propagation
-            connection.DialPress                        += (_, e) => this.InvokeOnAction(e, a => a.OnDialPress);
+            connection.DialDown                         += (_, e) => this.InvokeOnAction(e, a => a.OnDialDown);
+            connection.DialUp                           += (_, e) => this.InvokeOnAction(e, a => a.OnDialUp);
             connection.DialRotate                       += (_, e) => this.InvokeOnAction(e, a => a.OnDialRotate);
             connection.DidReceiveSettings               += (_, e) => this.InvokeOnAction(e, a => a.OnDidReceiveSettings);
             connection.KeyDown                          += (_, e) => this.InvokeOnAction(e, a => a.OnKeyDown);

--- a/src/SharpDeck/Events/Received/DialPayload.cs
+++ b/src/SharpDeck/Events/Received/DialPayload.cs
@@ -14,10 +14,5 @@ namespace SharpDeck.Events.Received
         /// Gets or sets the coordinates of a triggered action.
         /// </summary>
         public Coordinates Coordinates { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the dial is pressed.
-        /// </summary>
-        public bool Pressed { get; set; }
     }
 }

--- a/src/SharpDeck/StreamDeckAction.cs
+++ b/src/SharpDeck/StreamDeckAction.cs
@@ -154,11 +154,19 @@ namespace SharpDeck
         }
 
         /// <summary>
-        /// Occurs when <see cref="IStreamDeckConnection.DialPress"/> is received for this instance.
+        /// Occurs when <see cref="IStreamDeckConnection.DialDown"/> is received for this instance.
         /// </summary>
         /// <param name="args">The <see cref="ActionEventArgs{DialPayload}" /> instance containing the event data.</param>
         /// <returns>The task of handling the event.</returns>
-        protected internal virtual Task OnDialPress(ActionEventArgs<DialPayload> args)
+        protected internal virtual Task OnDialDown(ActionEventArgs<DialPayload> args)
+            => Task.CompletedTask;
+
+        /// <summary>
+        /// Occurs when <see cref="IStreamDeckConnection.DialUp"/> is received for this instance.
+        /// </summary>
+        /// <param name="args">The <see cref="ActionEventArgs{DialPayload}" /> instance containing the event data.</param>
+        /// <returns>The task of handling the event.</returns>
+        protected internal virtual Task OnDialUp(ActionEventArgs<DialPayload> args)
             => Task.CompletedTask;
 
         /// <summary>


### PR DESCRIPTION
The event "dialPress" was replaced by "dialDown" and "dialUp". Since Stream Deck v6.5 the old "dialPress" is removed from the API.